### PR TITLE
removed loop which indented additional projects on OSS page

### DIFF
--- a/open-source.html
+++ b/open-source.html
@@ -14,9 +14,9 @@ title: Code
       {% assign projects = site.projects | sort: 'title' %}
       {% for project in projects | sort: 'title' %}
         {% assign loopindex = forloop.index | modulo: 2 %}
-        {% if loopindex == 1 %}
+
           <div class="row">
-        {% endif %}
+
           <div class="full column">
             <article>
               <header>


### PR DESCRIPTION
The loop around creating a new row would indent a new project when displayed on the screen. Removing it so that we can add future OSS projects to the page